### PR TITLE
Feature/support proxy for freshclam

### DIFF
--- a/.github/workflows/auto-build-image.yml
+++ b/.github/workflows/auto-build-image.yml
@@ -1,0 +1,11 @@
+---
+name: Build Clam AV Every Week
+on:
+  schedule:
+    - cron: '0 4 * * 0'
+
+jobs:
+  create-docker-image:
+    name: Build a Docker image on Sunday at 4 am
+    uses: ./.github/workflows/build-image.yml
+    secrets: inherit

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,9 +1,8 @@
 ---
 name: Build and Publish ClamAV Image
 on:
-    # schedule:
-    #   - cron: '0 4 * * 0'
     workflow_dispatch:
+    workflow_call:
 
 env:
   DOCKER_NAME: clamav-rest
@@ -28,16 +27,10 @@ jobs:
 
       - name: Build Docker Image
         run: docker build . -t ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }}
-        # clamav-rest:20230525
-
-      - name: Scan Image
-        run: docker run aquasec/trivy:latest  image --timeout 5m --scanners vuln --exit-code 1 --severity CRITICAL,HIGH ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }}
 
       - name: Tag Image
         run: |
-          image_creation_date=$(date -d "$(docker inspect -f '{{ .Created }}' ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }})" +%s)
           docker tag ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }} ghcr.io/${{ env.GH_REPO }}/${{ env.IMAGE }}:${{ steps.date.outputs.date }}
-          docker tag ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }} ghcr.io/${{ env.GH_REPO }}/${{ env.IMAGE }}:$image_creation_date
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -48,3 +41,9 @@ jobs:
 
       - name: Push Image
         run: docker push --all-tags ghcr.io/${{ env.GH_REPO }}/${{ env.IMAGE }}
+
+      - name: Upload Artifact
+        uses: ishworkh/docker-image-artifact-upload@v1
+        with:
+          image: "${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }}"
+          retention_days: "8"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -7,7 +7,7 @@ on:
 env:
   DOCKER_NAME: clamav-rest
   IMAGE: clamav
-  GH_REPO: gsa-tts/fac
+  GH_REPO: GSA-TTS/clamav-rest
 
 jobs:
   build-clamav:
@@ -41,9 +41,3 @@ jobs:
 
       - name: Push Image
         run: docker push --all-tags ghcr.io/${{ env.GH_REPO }}/${{ env.IMAGE }}
-
-      - name: Upload Artifact
-        uses: ishworkh/docker-image-artifact-upload@v1
-        with:
-          image: "${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }}"
-          retention_days: "8"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,50 @@
+---
+name: Build and Publish ClamAV Image
+on:
+    # schedule:
+    #   - cron: '0 4 * * 0'
+    workflow_dispatch:
+
+env:
+  DOCKER_NAME: clamav-rest
+  IMAGE: clamav
+  GH_REPO: gsa-tts/fac
+
+jobs:
+  build-clamav:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Get Date
+        shell: bash
+        id: date
+        run: |
+          echo "date=$(date +%Y%m%d)" >> $GITHUB_OUTPUT
+
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Build Docker Image
+        run: docker build . -t ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }}
+        # clamav-rest:20230525
+
+      - name: Scan Image
+        run: docker run aquasec/trivy:latest  image --timeout 5m --scanners vuln --exit-code 1 --severity CRITICAL,HIGH ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }}
+
+      - name: Tag Image
+        run: |
+          image_creation_date=$(date -d "$(docker inspect -f '{{ .Created }}' ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }})" +%s)
+          docker tag ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }} ghcr.io/${{ env.GH_REPO }}/${{ env.IMAGE }}:${{ steps.date.outputs.date }}
+          docker tag ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }} ghcr.io/${{ env.GH_REPO }}/${{ env.IMAGE }}:$image_creation_date
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Image
+        run: docker push --all-tags ghcr.io/${{ env.GH_REPO }}/${{ env.IMAGE }}

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ Below is the complete list of available options that can be used to customize yo
 | `PCRE_MATCHLIMIT` | Maximum PCRE Match Calls - Default `100000` |
 | `PCRE_RECMATCHLIMIT` | Maximum Recursive Match Calls to PCRE - Default `2000` |
 | `SIGNATURE_CHECKS` | Check times per day for a new database signature. Must be between 1 and 50. - Default `2` |
+| `PROXY_SERVER` | Specify a proxy for freshclam to utilize, if applicable, set in environment variables - Optional |
+| `PROXY_PORT` | The port for the proxy server, if applicable, set in environment variables - Optional |
+| `PROXY_USERNAME` | The username for the proxy server, if applicable, set in environment variables - Optional |
+| `PROXY_PASSWORD` | The password for the proxy server, if applicable, set in environment variables - Optional |
 
 ## Networking
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ sed -i 's/^#PCREMatchLimit.*$/PCREMatchLimit '"$PCRE_MATCHLIMIT"'/g' /etc/clamav
 sed -i 's/^#PCRERecMatchLimit .*$/PCRERecMatchLimit '"$PCRE_RECMATCHLIMIT"'/g' /etc/clamav/clamd.conf
 
 if [ -n "$PROXY_SERVER" ]; then
-    sed -i 's/^#HTTPProxyServer .*$/HTTPProxyServer '"$PROXY_SERVER"'/g' /etc/clamav/freshclam.conf
+    sed -i 's~^#HTTPProxyServer .*~HTTPProxyServer '"$PROXY_SERVER"'~g' /etc/clamav/freshclam.conf
 
     # It's not required, but if they also provided a port, then configure it
     if [ -n "$PROXY_PORT" ]; then
@@ -27,7 +27,7 @@ if [ -n "$PROXY_SERVER" ]; then
     # It's not required, but if they also provided a username, then configure both the username and password
     if [ -n "$PROXY_USERNAME" ]; then
         sed -i 's/^#HTTPProxyUsername .*$/HTTPProxyUsername '"$PROXY_USERNAME"'/g' /etc/clamav/freshclam.conf
-        sed -i 's/^#HTTPProxyPassword .*$/HTTPProxyPassword '"$PROXY_PASSWORD"'/g' /etc/clamav/freshclam.conf
+        sed -i 's~^#HTTPProxyPassword .*~HTTPProxyPassword '"$PROXY_PASSWORD"'~g' /etc/clamav/freshclam.conf
     fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,22 @@ sed -i 's/^#MaxPartitions .*$/MaxPartitions '"$MAX_PARTITIONS"'/g' /etc/clamav/c
 sed -i 's/^#MaxIconsPE .*$/MaxIconsPE '"$MAX_ICONSPE"'/g' /etc/clamav/clamd.conf
 sed -i 's/^#PCREMatchLimit.*$/PCREMatchLimit '"$PCRE_MATCHLIMIT"'/g' /etc/clamav/clamd.conf
 sed -i 's/^#PCRERecMatchLimit .*$/PCRERecMatchLimit '"$PCRE_RECMATCHLIMIT"'/g' /etc/clamav/clamd.conf
+
+if [ -n "$PROXY_SERVER" ]; then
+    sed -i 's/^#HTTPProxyServer .*$/HTTPProxyServer '"$PROXY_SERVER"'/g' /etc/clamav/freshclam.conf
+
+    # It's not required, but if they also provided a port, then configure it
+    if [ -n "$PROXY_PORT" ]; then
+        sed -i 's/^#HTTPProxyPort .*$/HTTPProxyPort '"$PROXY_PORT"'/g' /etc/clamav/freshclam.conf
+    fi
+
+    # It's not required, but if they also provided a username, then configure both the username and password
+    if [ -n "$PROXY_USERNAME" ]; then
+        sed -i 's/^#HTTPProxyUsername .*$/HTTPProxyUsername '"$PROXY_USERNAME"'/g' /etc/clamav/freshclam.conf
+        sed -i 's/^#HTTPProxyPassword .*$/HTTPProxyPassword '"$PROXY_PASSWORD"'/g' /etc/clamav/freshclam.conf
+    fi
+fi
+
 (
     freshclam --daemon --checks=$SIGNATURE_CHECKS &
     clamd &


### PR DESCRIPTION
Test Case (with ajilaag/clamav-rest image):
```bash
/etc/clamav # ./test.sh 
Replaced proxy server #=> ensuring sed works with new delimiter when testing
Replaced proxy port #=> ensuring sed works with new delimiter when testing
Replaced proxy user and pass #=> ensuring sed works with new delimiter when testing

/etc/clamav # cat freshclam.conf | grep "HTTP*"
# The HTTPProxyServer may be prefixed with [scheme]:// to specify which kind
#   http://     HTTP Proxy. Default when no scheme or proxy type is specified.
#   https://    HTTPS Proxy. (Added in 7.52.0 for OpenSSL, GnuTLS and NSS)
HTTPProxyServer https://proxy-test.com
HTTPProxyPort 54321
HTTPProxyUsername TESTUSER
HTTPProxyPassword TEST/PASS
#HTTPUserAgent SomeUserAgentIdString
```

Usage:
If `$PROXY_SERVER` is not set in an environment variable, then none of this will run
If  `$PROXY_SERVER` is set then replace the value in `freshclam.conf`
- Since port, username and password are not required, only apply them to `freshclam.conf` if `$PROXY_PORT`, `$PROXY_USERNAME` and `$PROXY_PASSWORD` are set in an environment variable