### PR TITLE
Upgrade libcrypto3 to bump from 3.1.4-r1 -> 3.1.4-r4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine3.18 as build
 
 # Update libraries
-RUN apk update upgrade 
+RUN apk update upgrade
 
 # Set workdir
 WORKDIR /go/src
@@ -20,6 +20,9 @@ RUN  apk update upgrade && apk add --no-cache tzdata
 
 # Enable Bash & logrotate
 RUN apk add bash logrotate
+
+# Update lobcrypto3
+RUN apk upgrade libssl3 libcrypto3
 
 COPY clamavlogrotate /etc/logrotate.d/clamav
 


### PR DESCRIPTION
Addresses: https://github.com/GSA-TTS/FAC/issues/3246

```
#15 [stage-1  5/11] RUN apk upgrade libssl3 libcrypto3
#15 0.758 (1/2) Upgrading libcrypto3 (3.1.4-r1 -> 3.1.4-r4)
#15 1.022 (2/2) Upgrading libssl3 (3.1.4-r1 -> 3.1.4-r4)
#15 1.057 OK: 13 MiB in 23 packages
#15 DONE 1.2s
```