### PR TITLE
Upgrade libxml2 -> 2.11.7-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ RUN  apk update upgrade && apk add --no-cache tzdata
 # Enable Bash & logrotate
 RUN apk add bash logrotate
 
-# Update lobcrypto3
+# Update packages found by trivy
 RUN apk upgrade libssl3 libcrypto3
+RUN apk upgrade libxml2
 
 COPY clamavlogrotate /etc/logrotate.d/clamav
 


### PR DESCRIPTION
A vulnerability was found with the current version of `libxml2`. This PR addresses that.

```
#19 [stage-1  9/12] RUN apk --no-cache add clamav clamav-libunrar     && mkdir /run/clamav     && chown clamav:clamav /run/clamav
#19 0.408 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
#19 0.566 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
#19 0.742 (1/22) Installing libbz2 (1.0.8-r5)
#19 0.762 (2/22) Installing ca-certificates (20230506-r0)
#19 0.792 (3/22) Installing brotli-libs (1.0.9-r14)
#19 0.821 (4/22) Installing libunistring (1.1-r1)
#19 0.851 (5/22) Installing libidn2 (2.3.4-r1)
#19 0.877 (6/22) Installing nghttp2-libs (1.57.0-r0)
#19 0.898 (7/22) Installing libcurl (8.5.0-r0)
#19 0.926 (8/22) Installing libgcc (12.2.1_git20220924-r10)
#19 0.946 (9/22) Installing json-c (0.16-r3)
#19 0.969 (10/22) Installing libmspack (0.11_alpha-r0)
#19 0.991 (11/22) Installing pcre2 (10.42-r1)
#19 1.061 (12/22) Installing xz-libs (5.4.3-r0)
#19 1.086 (13/22) Installing libxml2 (2.11.7-r0) #### Upgraded version that patches the vulnerability
#19 1.115 (14/22) Installing clamav-libs (1.1.2-r0)
#19 1.260 (15/22) Installing freshclam (1.1.2-r0)
#19 1.279 Executing freshclam-1.1.2-r0.pre-install
#19 1.298 (16/22) Installing clamav-scanner (1.1.2-r0)
#19 1.445 (17/22) Installing clamav-clamdscan (1.1.2-r0)
#19 1.465 (18/22) Installing clamav-daemon (1.1.2-r0)
#19 1.492 Executing clamav-daemon-1.1.2-r0.pre-install
#19 1.497 (19/22) Installing musl-fts (1.2.7-r5)
#19 1.516 (20/22) Installing clamav (1.1.2-r0)
#19 1.546 (21/22) Installing libstdc++ (12.2.1_git20220924-r10)
#19 1.593 (22/22) Installing clamav-libunrar (1.1.2-r0)
#19 1.616 Executing busybox-1.36.1-r5.trigger
#19 1.619 Executing ca-certificates-20230506-r0.trigger
#19 1.643 OK: 74 MiB in 45 packages
#19 DONE 1.7s
```