### PR TITLE
Bumped go version to address security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.26.1
+ARG GO_VERSION=1.26.2
 FROM golang:${GO_VERSION}-alpine AS build
 
 # Update libraries


### PR DESCRIPTION
## Updates
- Bumped to latest minor go version which includes security patches.

This resolves failures with this scheduled gh workflow: https://github.com/GSA-TTS/FAC/actions/workflows/containers-push-upstream-to-ghcr.yml