### PR TITLE
Bumped go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.26.2
+ARG GO_VERSION=1.26.3
 FROM golang:${GO_VERSION}-alpine AS build
 
 # Update libraries

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.26.0
+ARG GO_VERSION=1.26.3
 FROM golang:${GO_VERSION}-alpine AS build
 
 RUN apk update && apk upgrade && apk add --no-cache git


### PR DESCRIPTION
Bumping go version to address vulnerabilities

Reference: https://github.com/GSA-TTS/FAC/actions/runs/27084964087/job/79937510984 