### PR TITLE
Bumped go version from 1.26.3 to 1.26.4

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -24,7 +24,7 @@ jobs:
           echo "date=$(date +%Y%m%d)" >> $GITHUB_OUTPUT
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build Docker Image
         run: docker build . -t ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }}
@@ -35,7 +35,7 @@ jobs:
           docker tag ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }} ghcr.io/${{ env.GH_REPO }}/${{ env.IMAGE }}:latest
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 FROM golang:${GO_VERSION}-alpine AS build
 
 # Update libraries

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 FROM golang:${GO_VERSION}-alpine AS build
 
 RUN apk update && apk upgrade && apk add --no-cache git


### PR DESCRIPTION
Bumped version to address security vulnerabilities

Reference: https://github.com/GSA-TTS/FAC/actions/runs/27370646319/job/80881719324